### PR TITLE
Revert "fix(deps): update dependency tslint-consistent-codestyle to ~1.11.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "tslint-consistent-codestyle": "~1.11.0",
+    "tslint-consistent-codestyle": "~1.8.0",
     "tslint-eslint-rules": "~4.1.0",
     "tslint-plugin-ikatyang": "~1.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,12 +1315,12 @@ tslint-config-prettier@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.9.0.tgz#391887644b66de4623f745a6c85672405cbcdcee"
 
-tslint-consistent-codestyle@~1.11.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.11.1.tgz#fa39ff5f5f8a25c537bd1e1f50de6190a2f4d70d"
+tslint-consistent-codestyle@~1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.8.0.tgz#ede0b5ec6777f8ff4426d9838bc9bf18e8174480"
   dependencies:
     tslib "^1.7.1"
-    tsutils "^2.21.0"
+    tsutils "^2.12.0"
 
 tslint-eslint-rules@~4.1.0:
   version "4.1.1"
@@ -1369,15 +1369,9 @@ tsutils@^1.4.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 
-tsutils@^2.12.1, tsutils@^2.8.0:
+tsutils@^2.12.0, tsutils@^2.12.1, tsutils@^2.8.0:
   version "2.21.2"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.21.2.tgz#902aa5987e1440c47673543d96752df8d44ab9c7"
-  dependencies:
-    tslib "^1.8.1"
-
-tsutils@^2.21.0:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.22.1.tgz#30450bd701be623b9e11a129df0c32322678461b"
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
Reverts ikatyang/tslint-config-ikatyang#65

Ref: https://github.com/renovateapp/renovate/issues/1584